### PR TITLE
Make recursively clean

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -29,7 +29,7 @@ flash:	$(TARGET)
 	avrdude $(AVRFLAGS) -U flash:w:$(TARGET)
 
 clean:
-	rm -f *.0 *.hex *.o usbdrv/*.o
+	find ./ -type f \( -name '*.0' -o -name '*.hex' -o -name '*.o' \) -exec rm {} \;
 
 fuse:
 	avrdude $(AVRFLAGS) -U efuse:w:$(EFUSE):m -U hfuse:w:$(HFUSE):m -U lfuse:w:$(LFUSE):m


### PR DESCRIPTION
The current rm command only checks the current directory and the listed
ones, in particular skipping other subdirectories.

Perhaps switch this out to something that operates with the Makefile
variables, avoiding the `find` command entirely?
